### PR TITLE
Add types to contentful

### DIFF
--- a/with_styled_components/lib/contentful/client.tsx
+++ b/with_styled_components/lib/contentful/client.tsx
@@ -1,6 +1,6 @@
-const contentful = require('contentful')
+import { createClient } from 'contentful';
 
-export const client = contentful.createClient({
-  space: process.env.CONTENTFUL_SPACE_ID,
-  accessToken: process.env.CONTENTFUL_ACCESS_TOKEN
-})
+export const client = createClient({
+  space: process.env.CONTENTFUL_SPACE_ID || '',
+  accessToken: process.env.CONTENTFUL_ACCESS_TOKEN || ''
+});

--- a/with_styled_components/pages/projects/index.tsx
+++ b/with_styled_components/pages/projects/index.tsx
@@ -1,21 +1,64 @@
-import { client } from "lib/contentful/client"
+import { Entry, EntryFieldTypes, EntrySkeletonType } from 'contentful';
+import { client } from 'lib/contentful/client';
+import { GetStaticProps, InferGetStaticPropsType } from 'next';
 
-export default function ProjectsPage({ projects }) {
-  console.log(projects)
-  return <h1>{projects}</h1>
+// We need to specify the props of our component, we do this here
+// by using the `InferGetStaticPropsType` helper from Next, which
+// takes in the return type of `getStaticProps` and returns the
+// correct type for our component props
+export default function ProjectsPage({
+  projects
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  console.log(projects);
+  return (
+    <h1>
+      {projects.map((p) => (
+        <p>{p.fields.name}</p>
+      ))}
+    </h1>
+  );
 }
 
-export async function getStaticProps() {
-  const res = await client.getEntries({ content_type: 'project'})
-  const projects = await res.items.json()
- 
-  // By returning { props: { posts } }, the Blog component
-  // will receive `posts` as a prop at build time
+/* These types should be in a types file somewhere else
+ * or even better, automatically generated
+ */
+
+// First we declare a type matching our Contentful Model,
+// `EntrySkeletonType` is a helper type that will create
+// the correct type for the `fields` property.
+// It takes in an object type of the fiels and the content
+// type id as generic parameters.
+type ProjectSkeleton = EntrySkeletonType<
+  {
+    name: EntryFieldTypes.Symbol;
+    description: EntryFieldTypes.Symbol;
+  },
+  'project'
+>;
+
+// To get the correct type for a specific entry we use
+// the `Entry` type, which takes in the skeleton we created
+// above and a modifier, in this case `undefined` since
+// we don't have any localizations
+type ProjectEntry = Entry<ProjectSkeleton, undefined>;
+
+/***** End types */
+
+// We need to type the props we are returning from `getStaticProps`
+// using the `GetStaticProps` from Next, that takes in a generic
+// type describing the props to our component
+export const getStaticProps: GetStaticProps<{
+  projects: ProjectEntry[];
+}> = async () => {
+  // We pass in our skeleton type to the contentful method
+  const res = await client.getEntries<ProjectSkeleton>({
+    content_type: 'project'
+  });
+  const projects = await res.items;
+
   return {
     props: {
-      projects,
-    },
-  }
-}
-
-
+      projects
+    }
+  };
+};


### PR DESCRIPTION
Det man behöver göra när man har ett sånt här externt beroende (contentful), så behöver man på något sätt få in dess typer. Man bör anse Contentfuls Content Model som “source of truth”, det är där man anger hur ens innehåll är strukturerat.

På https://www.contentful.com/developers/docs/javascript/tutorials/typescript-in-javascript-client-library/ finns information från Contentful om hur man anger typer för Contentful.

Det här kan man göra antingen manuellt, eller automatiskt. Om man gör det manuellt skapar man upp typer som

```typescript
type BlogPostSkeleton =
{
  contentTypeId: "blogPost",
  fields: {
    productName: Contentful.EntryFieldTypes.Text,
    image: Contentful.EntryFieldTypes.Asset,
    price: Contentful.EntryFieldTypes.Number,
    categories: Contentful.EntryFieldTypes.Array<Contentful.EntryFieldTypes.EntryLink<CategorySkeleton>>,
  }
}
```

Att göra det automatiskt är dock att rekommendera, jag skriver snart hur vi har löst det på jobbet.

När du sen har typerna från contentful i ditt projekt, så kan du ange vilken typ du får när du gör dina contentful-anrop.

```typescript
client.getEntries<BlogPostSkeleton>()
```

eller i ditt fall

```typescript
client.getEntries<ProjectSkeleton>({ content_type: 'project' });
```

Så om vi kollar på din kod. Först måste vi typa din contentful-klient korrekt:

```typescript
import { createClient } from 'contentful';

export const client = createClient({
  space: process.env.CONTENTFUL_SPACE_ID || '',
  accessToken: process.env.CONTENTFUL_ACCESS_TOKEN || ''
});
```

Sen måste vi lägga in rätt typer i sidan:

```typescript
import { Entry, EntryFieldTypes, EntrySkeletonType } from 'contentful';
import { client } from 'lib/contentful/client';
import { GetStaticProps, InferGetStaticPropsType } from 'next';

// We need to specify the props of our component, we do this here
// by using the `InferGetStaticPropsType` helper from Next, which
// takes in the return type of `getStaticProps` and returns the
// correct type for our component props
export default function ProjectsPage({
  projects
}: InferGetStaticPropsType<typeof getStaticProps>) {
  console.log(projects);
  return (
    <h1>
      {projects.map((p) => (
        <p>{p.fields.name}</p>
      ))}
    </h1>
  );
}

/* These types should be in a types file somewhere else
 * or even better, automatically generated
 */

// First we declare a type matching our Contentful Model,
// `EntrySkeletonType` is a helper type that will create
// the correct type for the `fields` property.
// It takes in an object type of the fiels and the content
// type id as generic parameters.
type ProjectSkeleton = EntrySkeletonType<
  {
    name: EntryFieldTypes.Symbol;
    description: EntryFieldTypes.Symbol;
  },
  'project'
>;

// To get the correct type for a specific entry we use
// the `Entry` type, which takes in the skeleton we created
// above and a modifier, in this case `undefined` since
// we don't have any localizations
type ProjectEntry = Entry<ProjectSkeleton, undefined>;

/***** End types */

// We need to type the props we are returning from `getStaticProps`
// using the `GetStaticProps` from Next, that takes in a generic
// type describing the props to our component
export const getStaticProps: GetStaticProps<{
  projects: ProjectEntry[];
}> = async () => {
  // We pass in our skeleton type to the contentful method
  const res = await client.getEntries<ProjectSkeleton>({
    content_type: 'project'
  });
  const projects = await res.items;

  return {
    props: {
      projects
    }
  };
};
```

Att skriva in alla ens typer från Contentful-modellen är onödigt dubbelarbete och riskerar att bli fel. Så därför bör man använda ett verktyg för att generera typerna automatisk. I mitt team använder vi oss av ett paket som heter `cf-content-types-generator`. Det är ett skript som man ger en Management API-nyckel från Contentful (obs, annan än Content Delivery API som du använder för att hämta innehåll) och som sen spottar ur sig typer.

Efter att ha installerat det som en dev dependency i ditt projekt kan du använda samma skript som oss, definierat i `package.json`

```json
scripts: {
  "generate-types-contentful": "dotenv -e .env.local -- npm run contentful-typegen",
  "contentful-typegen": "cf-content-types-generator -g -s $CONTENTFUL_SPACE_ID -t $CONTENTFUL_MANAGEMENT_API_KEY -e $CONTENTFUL_ENV -X -o ./src/types/generated/contentful"
}
```

Där det ena kommandot använder sig av paketet `dotenv-cli` för att ladda environment-variabler från filen `.env.local` (kan vara vilken fil som helst), och som sen kör andra skriptet.

Det andra skriptet kör typ-generatorn och mosar ut resultatet i en mapp. Då får du alla typer för alla innehållstyper automatiskt utan att du behöver göra något.